### PR TITLE
add MSRP default value fix

### DIFF
--- a/backend/scraper/suppliers/playstation.py
+++ b/backend/scraper/suppliers/playstation.py
@@ -54,6 +54,7 @@ def get_giveaways(supplier_id):
                                datetime.timedelta(days=32)).replace(day=2, hour=0, minute=0, second=0, microsecond=0)
 
             # loop over radio buttons to find the MSRP
+            msrp = None
             for i in range(3):
                 msrp_container = None
                 msrp_container = soup2.find(


### PR DESCRIPTION
# Why
We need to fix the following error, happening when no MSRP is found for a Playstation giveaway
```
5|scraper  | UnboundLocalError: cannot access local variable 'msrp' where it is not associated with a value
5|scraper  | Traceback (most recent call last):
5|scraper  |   File "/home/catruzz/JustFreeGames/backend/scraper/suppliers/playstation.py", line 76, in get_giveaways
5|scraper  |     'msrp': msrp,
5|scraper  |             ^^^^
5|scraper  | UnboundLocalError: cannot access local variable 'msrp' where it is not associated with a value
5|scraper  | Traceback (most recent call last):
5|scraper  |   File "/home/catruzz/JustFreeGames/backend/scraper/suppliers/playstation.py", line 24, in get_giveaways
5|scraper  |     for item in monthly_games.find_all('div', class_='box'):
5|scraper  |                 ^^^^^^^^^^^^^^^^^^^^^^
```

# How
Just added the default MSRP value to be `None`