### PR TITLE
return logs in error handler + reduce logs line to 100

### DIFF
--- a/backend/chatbot/main.py
+++ b/backend/chatbot/main.py
@@ -930,14 +930,14 @@ async def unknown(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     return ConversationHandler.END
 
 
-async def logs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+async def logs(update: Update, context: ContextTypes.DEFAULT_TYPE, disable_notification=False) -> int:
     global pause_publish, pause_review
     """Send logs file."""
     text = "📂 Saving logs... 📂"
-    await send_message(context=context, text=text, photo=False)
-    os.system('pm2 logs --lines 500 --nostream > logs/logs.txt')
+    await send_message(context=context, text=text, photo=False, disable_notification=disable_notification)
+    os.system('pm2 logs --lines 100 --nostream > logs/logs.txt')
     with open('logs/logs.txt', 'rb') as file:
-        await context.bot.send_document(chat_id=DEVELOPER_CHAT_ID, document=file)
+        await context.bot.send_document(chat_id=DEVELOPER_CHAT_ID, document=file, disable_notification=disable_notification)
 
     pause_publish = False
     pause_review = False
@@ -982,7 +982,7 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE, cust
 
     # Finally, send the message, without notification
     await send_message(context=context, text=text, disable_notification=True, photo=False)
-    return ConversationHandler.END
+    return logs(update, context, disable_notification=True)
 
 
 def main() -> None:


### PR DESCRIPTION
# Why
We need to read logs as soon as an error occur, to be able to debug easily.

# How
When the `error_handler` method is launched (automatically when any exception is thrown), instead of exiting the conversation, we now export and send the logs to the user by calling the the `logs` method with the `disable_notification` option set to `True`.
In addition to that, the exported lines are reduced from 500 to 100 lines.