### PR TITLE
fix mmobomb item type scraping

### DIFF
--- a/backend/scraper/suppliers/mmobomb.py
+++ b/backend/scraper/suppliers/mmobomb.py
@@ -31,7 +31,7 @@ def get_giveaways(supplier_id):
     try:
         soup = BeautifulSoup(page_source, 'html.parser')
 
-        for item in soup.find_all('div', class_='content'):
+        for item in soup.find_all('article', class_='content'):
             button = item.find('button', type='button')
             if not button or button.text.strip() != "Open":
                 continue


### PR DESCRIPTION
# Why
MMOBOMB scraper is not getting any giveaway since a long time.

# How
Aligned the scraper code to match the page code: we were looking for `div.content` while all the entries are wrapped with a `article.content` element.