### PR TITLE
PM2: add backend/scraper/utils/__pycache__ to pm2 ignoreWatch paths

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,6 +5,7 @@ const ignoreWatch = [
   "\\.git",
   "backend/scraper/__pycache__",
   "backend/scraper/suppliers/__pycache__",
+  "backend/scraper/utils/__pycache__",
   "public",
   "logs",
   "node_modules",


### PR DESCRIPTION
# Why
We need to prevent PM2 processes relaunch when the `backend/scraper/utils/__pycache__` changes.

# How
Just added the path to the `ecosystem.config.js#ignoreWatch` constant.