### PR TITLE
Amazon scraper: read expiration date also for LOOT type giveaways

### DIFF
--- a/backend/scraper/suppliers/amazon.py
+++ b/backend/scraper/suppliers/amazon.py
@@ -87,7 +87,7 @@ def get_giveaways(supplier_id):
                 giveaway_platforms = lib.get_giveaway_platforms(
                     'amazon')
                 expiration_date = None
-                if giveaway_type == Giveaway.Type.GAME and url not in scraped_urls:
+                if url not in scraped_urls:
                     #  keep track of scraped url
                     scraped_urls.append(url)
                     browser.get(url)


### PR DESCRIPTION
# Why
We need to read expiration date also for LOOT type giveaways

# How
Just removed the giveaway type filter to decide whether to open the giveaway page or not, since the markup is identical to the one used for the GAME type giveaways