### PR TITLE
fix EpicGames product slug parsing

### DIFF
--- a/backend/scraper/suppliers/epic_games.py
+++ b/backend/scraper/suppliers/epic_games.py
@@ -27,7 +27,17 @@ def get_giveaways(supplier_id):
                         el['price']['lineOffers'][0]['appliedRules'][0]['endDate'], '%Y-%m-%dT%H:%M:%S.%fZ')
                 except:
                     expiration_date = None
-                product_slug = el['productSlug'] if el['productSlug'] else el['offerMappings'][0]['pageSlug']
+
+                product_slug = ''
+                if el['productSlug']:
+                    product_slug = el['productSlug']
+                elif el['offerMappings']:
+                    product_slug = el['offerMappings'][0]['pageSlug']
+                elif el['productSlug']:
+                    product_slug = el['productSlug']
+                elif el['urlSlug']:
+                    product_slug = el['urlSlug']
+
                 giveaways.append({
                     'platforms': giveaway_platforms,
                     'type': giveaway_type,


### PR DESCRIPTION
# Why
We need to fix the Epic Games scraper due to an error in the slug parsing method.

# How
The `el['offerMappings'][0]` seems to be missing in the last giveaway, so we try to fall back to different new (?) properties to get the right slug.
In the end we leave the slug empty if it's not found, so that the giveaway is saved anyway and can be fixed by the reviewer before publishing.