### PR TITLE
fix amazon url

### DIFF
--- a/backend/scraper/suppliers/amazon.py
+++ b/backend/scraper/suppliers/amazon.py
@@ -17,7 +17,7 @@ from backend.api import api
 def get_giveaways(supplier_id):
     giveaways = []
     giveaways_url = 'https://gaming.amazon.com'
-    base_giveaways_url = 'https://luna.amazon.it'
+    base_giveaways_url = 'https://luna.amazon.com'
 
     timeout = 15
 


### PR DESCRIPTION
# Why
We are sending giveaways using the Italian domain site, but we need to change it using the worldwide one

# How
- changed `base_giveaways_url = 'https://luna.amazon.it'` to `base_giveaways_url = 'https://luna.amazon.com'`